### PR TITLE
Updating hub URLs in error page and example env

### DIFF
--- a/datahub-indexer/env.example
+++ b/datahub-indexer/env.example
@@ -8,6 +8,6 @@ ES_SITE=datahub
 DYNAMODB_TABLE=test-table
 LAMBDA_FUNCTION=test-function
 LARGE_MESSAGE_BUCKET=large-message-bucket
-DATAHUB_ASSETS_URL=https://hub.jncc.gov.uk
+DATAHUB_ASSETS_URL=https://jncc.gov.uk/resources/
 USE_LOCALSTACK=true
 ASSET_QUERY_DELAY=0

--- a/jncc-search-frontend/error-pages/error.html
+++ b/jncc-search-frontend/error-pages/error.html
@@ -162,7 +162,7 @@
                             <h3>Our work</h3>
                             <ul class="footer-nav no-bullet">
                                 <li><a href="https://jncc.gov.uk/our-work/our-work-a-z/">Our work A-Z</a></li>
-                                <li><a href="https://hub.jncc.gov.uk/">Resource hub</a></li>
+                                <li><a href="https://jncc.gov.uk/resources/">Resource hub</a></li>
                                 <li><a href="https://jncc.gov.uk/about-jncc/jncc-blog/">JNCC Blog</a></li>
                                 <li><a href="https://jncc.gov.uk/news/">News</a></li>
                             </ul>


### PR DESCRIPTION
I noticed I hadn't updated the hub URL in the data.jncc error pages and looks like it needs updating for search as well.